### PR TITLE
Add debt tracking event in vault liquidation

### DIFF
--- a/contracts/vaultManager/VaultManager.sol
+++ b/contracts/vaultManager/VaultManager.sol
@@ -660,6 +660,7 @@ contract VaultManager is VaultManagerERC721, IVaultManagerFunctions {
                 // There may be an edge case in which: `amounts[i] = (currentDebt * BASE_PARAMS) / surcharge + 1`
                 // In this case, as long as `surcharge < BASE_PARAMS`, there cannot be any underflow in the operation
                 // above
+                emit InternalDebtUpdated(vaultIDs[i], vault.normalizedDebt, 0);
             } else {
                 vaultData[vaultIDs[i]].collateralAmount -= collateralReleased;
                 // In the case where the full debt is being repaid, `amounts[i]` must be rounded above


### PR DESCRIPTION
This was the only spot in the contract where debt in a vault was changed without firing an `InternalDebtUpdated` event.
It is possible to track the debt update by checking for `LiquidatedVaults` event when a vault gets his debt zeroed, but it would add technical debt to TG mappings. 