### PR TITLE
Update TokenPolygonUpgradeable.sol: Improves 'onlyGovernor' and 'onlyGovernorOrGuardian'

### DIFF
--- a/contracts/agToken/polygon/TokenPolygonUpgradeable.sol
+++ b/contracts/agToken/polygon/TokenPolygonUpgradeable.sol
@@ -161,13 +161,13 @@ contract TokenPolygonUpgradeable is
 
     /// @notice Checks whether the `msg.sender` has the governor role or not
     modifier onlyGovernor() {
-        checkGovernor();
+        _checkGovernor();
         _;
     }
 
     /// @notice Checks whether the `msg.sender` has the governor role or the guardian role
     modifier onlyGovernorOrGuardian() {
-        checkGovernorOrGuardian();
+        _checkGovernorOrGuardian();
         _;
     }
 
@@ -184,12 +184,12 @@ contract TokenPolygonUpgradeable is
     }
 
     /// @dev Internal function for 'onlyGovernor' modifier
-    function checkGovernor() internal view {
+    function _checkGovernor() internal view {
         if (!ITreasury(treasury).isGovernor(msg.sender)) revert NotGovernor();
     }
 
     /// @dev Internal function for 'onlyGovernorOrGuardian' modifier
-    function checkGovernorOrGuardian() internal view{
+    function _checkGovernorOrGuardian() internal view{
         if (!ITreasury(treasury).isGovernorOrGuardian(msg.sender)) revert NotGovernorOrGuardian();
     }
 

--- a/contracts/agToken/polygon/TokenPolygonUpgradeable.sol
+++ b/contracts/agToken/polygon/TokenPolygonUpgradeable.sol
@@ -161,13 +161,13 @@ contract TokenPolygonUpgradeable is
 
     /// @notice Checks whether the `msg.sender` has the governor role or not
     modifier onlyGovernor() {
-        if (!ITreasury(treasury).isGovernor(msg.sender)) revert NotGovernor();
+        checkGovernor();
         _;
     }
 
     /// @notice Checks whether the `msg.sender` has the governor role or the guardian role
     modifier onlyGovernorOrGuardian() {
-        if (!ITreasury(treasury).isGovernorOrGuardian(msg.sender)) revert NotGovernorOrGuardian();
+        checkGovernorOrGuardian();
         _;
     }
 
@@ -181,6 +181,16 @@ contract TokenPolygonUpgradeable is
         treasury = _treasury;
         treasuryInitialized = true;
         emit TreasuryUpdated(_treasury);
+    }
+
+    /// @dev Internal function for 'onlyGovernor' modifier
+    function checkGovernor() internal view {
+        if (!ITreasury(treasury).isGovernor(msg.sender)) revert NotGovernor();
+    }
+
+    /// @dev Internal function for 'onlyGovernorOrGuardian' modifier
+    function checkGovernorOrGuardian() internal view{
+        if (!ITreasury(treasury).isGovernorOrGuardian(msg.sender)) revert NotGovernorOrGuardian();
     }
 
     // =========================== External Function ===============================


### PR DESCRIPTION
This PR aims to optimize the gas by refactoring these two modifiers, cuz they were used the most in this particular contract and have the most impact on the contract bytecode size while deployment. Let's dive in and seek why it is done!!

Usually, Modifiers code is copied in all instances where it's used and thus increasing the size of bytecode which costs gas.
Now the question comes -> why just these two modifiers, there were more?
Well yeah, there were but this refactoring is done at the cost of JUMP opcode (i.e as you can see modifier need to look for the particular internal function inhibited inside its code). So it's always beneficial to use this kind of refactoring only in the cases where any modifier is used 2 or more than 2 times (btw 2 is not the fixed number, just a basic idea. Better is to have a trade-off and see which works better).

Enough theory talks, Let's see it working.
So I created a similar basic look code, which have two modifiers `onlyBuyer` and `onlySeller` and they are being used in 3 and 5 functions respectively (just for mimicking the original one). Here's the code:

```
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

contract Demo{
    address public seller;
    address public buyer;

    error notBuyer();
    error notSeller();

    modifier onlyBuyer(address _buyer){
        if(_buyer != buyer) revert notBuyer();
        _;
    }
    modifier onlySeller(address _seller){
        if(_seller != seller) revert notSeller();
        _;
    }

    function Buyer1(address buyer_) external onlyBuyer(buyer_){
        // some code
    }

    function Buyer2(address buyer_) external onlyBuyer(buyer_){
        // some code
    }

    function Buyer3(address buyer_) external onlyBuyer(buyer_){
        // some code
    }

    function Seller1(address seller_) external onlySeller(seller_){
        // some code
    }

    function Seller2(address seller_) external onlySeller(seller_){
        // some code
    }

    function Seller3(address seller_) external onlySeller(seller_){
        // some code
    }

    function Seller4(address seller_) external onlySeller(seller_){
        // some code
    }

    function Seller5(address seller_) external onlySeller(seller_){
        // some code
    }
}
```

At first, I ran this code with simple modifiers like we usually use and clicked a snapshot of the amount of gas it used:

![Screenshot (22)](https://github.com/AngleProtocol/borrow-contracts/assets/88618913/12c848fb-c65d-4d7d-a148-b7984cda8be0)

and then after making the required changes like I have done in this PR, or just see the code itself (just the changed part):

```
    modifier onlyBuyer(address _buyer){
        checkBuyer(_buyer);
        _;
    }
    modifier onlySeller(address _seller){
        checkSeller(_seller);
        _;
    }

    function checkBuyer(address _buyer) internal view{
        if (_buyer != buyer) revert notBuyer();
    }

    function checkSeller(address _seller) internal view{
        if (_seller != seller) revert notSeller();
    }
```

I got these results which were really striking!!

![Screenshot (23)](https://github.com/AngleProtocol/borrow-contracts/assets/88618913/262f4ca1-a757-4e0c-9c09-ec1b5890526d)

Thanks for the time you took in order to read it all. That's what the change I felt in this particular file. If you know why we shouldn't make these changes then do tell me about it. Will be a great learning experience then!!